### PR TITLE
Hide results on other pages

### DIFF
--- a/scripts/aboutController.js
+++ b/scripts/aboutController.js
@@ -2,6 +2,7 @@
   var aboutController = {};
   aboutController.reveal = function() {
     $('.tab-content').hide();
+    $('.card-data').remove();
     $('#about').fadeIn();
   }
   module.aboutController = aboutController;

--- a/scripts/formRevealer.js
+++ b/scripts/formRevealer.js
@@ -3,6 +3,7 @@
   formRevealer.reveal = function() {
     $('#loadingSvg').hide();
     $('.tab-content').hide();
+    $('.card-data').remove();
     $('#searchForm').fadeIn();
   }
   module.formRevealer = formRevealer;

--- a/scripts/videosController.js
+++ b/scripts/videosController.js
@@ -2,6 +2,7 @@
   var videosController = {};
   videosController.reveal = function() {
     $('.tab-content').hide();
+    $('.card-data').remove();
     $('#videos').fadeIn();
   }
   module.videosController = videosController;


### PR DESCRIPTION
Fixed issue where results display when navigating to other nav sections, removing the results so they don't stay when you go back to the home page.